### PR TITLE
Container-ify project

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,10 @@ Port 443 (TCP) — HTTPS
   - Instead of having a latch enforce synchronization on consumption, configure R-MQ to provision a thread for every consume
   - Use threadsafe Spring component to track concurrent "active" scans, implement interface "Scanner", explicitly wire in rather than single threaded impl
 - Publish OCI image of application
-  - Docker command (work in progress): ` docker run -d -p 8080:8080 -p 5432:5432 -p 5672:5672  --name port-scanner port-scanner:latest`
+  - Docker command (work in progress): `docker run -d -p 8080:8080 --name port-scanner port-scanner:latest`
+  - helpful commands:
+    - `sudo docker run -it --entrypoint /bin/bash <container_name>`
+  - Determine how to allow for contineraized application reach infra at localhost:5432 (PSQL) & localhost:5672 (RabbitMQ), without having to provision virtual network space
 - Deploy and run in kubernetes easily via helm ->
   - Build out support and instructions to reference application image build
   - Have written out template files to support initializing and running infrastructure 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,12 @@ Port 443 (TCP) — HTTPS
 - Java Version: 17
 - main class: com.ian.davidson.port.scanner.PortScannerApplication
 - program args I use in addition to application.yml:
-  - `spring.jpa.show-sql=true`   
-  - `spring.jpa.properties.hibernate.format_sql=true`
+  - `--spring.jpa.show-sql=true`
+  - `--spring.jpa.properties.hibernate.format_sql=true`
+  - `--spring.profiles.active=dev`
+
+### Swagger link
+- http://localhost:8080/scanner/swagger-ui/index.html#
 
 ## Required Infrastructure notes:
 ### Postgres:
@@ -105,10 +109,9 @@ Port 443 (TCP) — HTTPS
   - Instead of having a latch enforce synchronization on consumption, configure R-MQ to provision a thread for every consume
   - Use threadsafe Spring component to track concurrent "active" scans, implement interface "Scanner", explicitly wire in rather than single threaded impl
 - Publish OCI image of application
-  - Docker command (work in progress): `docker run -d -p 8080:8080 --name port-scanner port-scanner:latest`
+  - Docker command (work in progress): `docker run -d --name port-scanner -p 8080:8080 -p 9080:9080 port-scanner:latest`
   - helpful commands:
-    - `sudo docker run -it --entrypoint /bin/bash <container_name>`
-  - Determine how to allow for contineraized application reach infra at localhost:5432 (PSQL) & localhost:5672 (RabbitMQ), without having to provision virtual network space
+    - `sudo docker run -it --entrypoint sh <container_name>`
 - Deploy and run in kubernetes easily via helm ->
   - Build out support and instructions to reference application image build
   - Have written out template files to support initializing and running infrastructure 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Port 443 (TCP) — HTTPS
   - Instead of having a latch enforce synchronization on consumption, configure R-MQ to provision a thread for every consume
   - Use threadsafe Spring component to track concurrent "active" scans, implement interface "Scanner", explicitly wire in rather than single threaded impl
 - Publish OCI image of application
+  - Docker command (work in progress): ` docker run -d -p 8080:8080 -p 5432:5432 -p 5672:5672  --name port-scanner port-scanner:latest`
 - Deploy and run in kubernetes easily via helm ->
   - Build out support and instructions to reference application image build
   - Have written out template files to support initializing and running infrastructure 

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import java.time.LocalDateTime
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.3.1'
@@ -68,11 +70,12 @@ jib() {
 	}
 	to {
 		image = project.name.toString()
-		tags = ["latest"]
+		tags = ["latest", LocalDateTime.now().format("yyyyMMdd-HHmmss")]
 	}
 	container {
 		labels = [maintainer: 'Ian Davidson']
 		creationTime = 'USE_CURRENT_TIMESTAMP'
+		args = ["--spring.profiles.active=docker"]
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,13 @@ dependencies {
 
 jib() {
 	from {
-		image = 'azul/zulu-openjdk-distroless:17'
+		image = 'amazoncorretto:17.0.7-alpine'
+		platforms {
+			platform {
+				architecture = 'arm64'
+				os = 'linux'
+			}
+		}
 	}
 	to {
 		image = project.name.toString()

--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ jib() {
 	container {
 		labels = [maintainer: 'Ian Davidson']
 		creationTime = 'USE_CURRENT_TIMESTAMP'
-		args = ["--spring.profiles.active=docker"]
+		args = ["--spring.profiles.active=container"]
 	}
 }
 

--- a/src/main/java/com/ian/davidson/port/scanner/async/AsyncConfig.java
+++ b/src/main/java/com/ian/davidson/port/scanner/async/AsyncConfig.java
@@ -1,4 +1,4 @@
-package com.ian.davidson.port.scanner.config;
+package com.ian.davidson.port.scanner.async;
 
 import lombok.Data;
 import org.springframework.context.annotation.Configuration;
@@ -7,7 +7,7 @@ import org.springframework.beans.factory.annotation.Value;
 
 @Configuration
 @Data
-public class ScannerConfig {
+public class AsyncConfig {
 
     private final int timeout; //in ms
     private final int threadPoolCoreSize;
@@ -15,11 +15,11 @@ public class ScannerConfig {
     private final String threadNamePrefix;
     private final int queueSize;
 
-    public ScannerConfig(@Value("${scanner.time-out}") final int timeout,
-                         @Value("${scanner.thread-pool-core}") final int threadPoolCoreSize,
-                         @Value("${scanner.thread-pool-max}") final int threadPoolMaxSize,
-                         @Value("${scanner.thread-name-prefix}") final String threadNamePrefix,
-                         @Value("${scanner.queue-size}") final int queueSize){
+    public AsyncConfig(@Value("${scanner.async.time-out}") final int timeout,
+                         @Value("${scanner.async.thread-pool-core}") final int threadPoolCoreSize,
+                         @Value("${scanner.async.thread-pool-max}") final int threadPoolMaxSize,
+                         @Value("${scanner.async.thread-name-prefix}") final String threadNamePrefix,
+                         @Value("${scanner.async.queue-size}") final int queueSize){
 
         this.timeout = timeout;
         this.threadPoolCoreSize = threadPoolCoreSize;

--- a/src/main/java/com/ian/davidson/port/scanner/async/ThreadPoolConfig.java
+++ b/src/main/java/com/ian/davidson/port/scanner/async/ThreadPoolConfig.java
@@ -1,6 +1,5 @@
 package com.ian.davidson.port.scanner.async;
 
-import com.ian.davidson.port.scanner.config.ScannerConfig;
 import java.util.concurrent.Executor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,19 +10,19 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 @Configuration
 public class ThreadPoolConfig {
 
-    private final ScannerConfig scannerConfig;
+    private final AsyncConfig asyncConfig;
 
-    public ThreadPoolConfig(final ScannerConfig scannerConfig) {
-        this.scannerConfig = scannerConfig;
+    public ThreadPoolConfig(final AsyncConfig asyncConfig) {
+        this.asyncConfig = asyncConfig;
     }
 
     @Bean
     public Executor taskExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(scannerConfig.getThreadPoolCoreSize());
-        executor.setMaxPoolSize(scannerConfig.getThreadPoolMaxSize());
-        executor.setQueueCapacity(scannerConfig.getQueueSize());
-        executor.setThreadNamePrefix("ThreadPool-");
+        executor.setCorePoolSize(asyncConfig.getThreadPoolCoreSize());
+        executor.setMaxPoolSize(asyncConfig.getThreadPoolMaxSize());
+        executor.setQueueCapacity(asyncConfig.getQueueSize());
+        executor.setThreadNamePrefix(asyncConfig.getThreadNamePrefix());
         executor.initialize();
         return executor;
     }

--- a/src/main/java/com/ian/davidson/port/scanner/config/RabbitConfig.java
+++ b/src/main/java/com/ian/davidson/port/scanner/config/RabbitConfig.java
@@ -20,8 +20,8 @@ public class RabbitConfig {
     private final String queueName;
     private final String topicExchangeName;
 
-    public RabbitConfig(@Value("${rabbit.queue-name}") String queueName,
-                        @Value("${rabbit.topic-name-dispatch}") String topicExchangeName){
+    public RabbitConfig(@Value("${scanner.rabbit.queue-name}") String queueName,
+                        @Value("${scanner.rabbit.topic-name-dispatch}") String topicExchangeName){
         this.queueName = queueName;
         this.topicExchangeName = topicExchangeName;
     }

--- a/src/main/java/com/ian/davidson/port/scanner/model/entity/ScanResult.java
+++ b/src/main/java/com/ian/davidson/port/scanner/model/entity/ScanResult.java
@@ -2,6 +2,8 @@ package com.ian.davidson.port.scanner.model.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -44,6 +46,7 @@ public class ScanResult {
     @NotNull
     private Integer timeOut;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     @NotNull
     private ConnectionStatus status;

--- a/src/main/java/com/ian/davidson/port/scanner/service/impl/MultiThreadScanner.java
+++ b/src/main/java/com/ian/davidson/port/scanner/service/impl/MultiThreadScanner.java
@@ -1,8 +1,8 @@
 package com.ian.davidson.port.scanner.service.impl;
 
+import com.ian.davidson.port.scanner.async.AsyncConfig;
 import com.ian.davidson.port.scanner.async.ScanOperationExecutor;
 import com.ian.davidson.port.scanner.async.ScanOperationTask;
-import com.ian.davidson.port.scanner.config.ScannerConfig;
 import com.ian.davidson.port.scanner.model.entity.ScanResult;
 import com.ian.davidson.port.scanner.model.queue.ScanItinerary;
 import com.ian.davidson.port.scanner.model.scan.ScanOperation;
@@ -19,19 +19,19 @@ import org.springframework.stereotype.Service;
 @Service
 public class MultiThreadScanner implements Scanner {
 
-    private final ScanOperationTransformer scanOperationTransformer;
+    private final AsyncConfig asyncConfig;
     private final ScanOperationExecutor scanOperationExecutor;
-    private final ScannerConfig scannerConfig;
     private final ScanResultRepository scanResultRepository;
+    private final ScanOperationTransformer scanOperationTransformer;
 
-    public MultiThreadScanner(final ScanOperationTransformer scanOperationTransformer,
+    public MultiThreadScanner(final AsyncConfig asyncConfig,
                               final ScanOperationExecutor scanOperationExecutor,
-                              final ScannerConfig scannerConfig,
-                              final ScanResultRepository scanResultRepository) {
-        this.scanOperationTransformer = scanOperationTransformer;
+                              final ScanResultRepository scanResultRepository,
+                              final ScanOperationTransformer scanOperationTransformer) {
+        this.asyncConfig = asyncConfig;
         this.scanOperationExecutor = scanOperationExecutor;
-        this.scannerConfig = scannerConfig;
         this.scanResultRepository = scanResultRepository;
+        this.scanOperationTransformer = scanOperationTransformer;
     }
 
     @Override
@@ -42,7 +42,7 @@ public class MultiThreadScanner implements Scanner {
         //convert into atomic tasks to be done in parallel
         List<ScanOperation> scanOperations = scanOperationTransformer.scanItineraryToScanOperations(scanItinerary);
         List<ScanOperationTask> tasks = scanOperations.stream()
-                .map(op -> ScanOperationTask.builder().scanOperation(op).timeout(scannerConfig.getTimeout()).build()).toList();
+                .map(op -> ScanOperationTask.builder().scanOperation(op).timeout(asyncConfig.getTimeout()).build()).toList();
 
         //execute tasks
         List<ScanResult> scanResults = Collections.synchronizedList(new ArrayList<>());

--- a/src/main/java/com/ian/davidson/port/scanner/service/impl/SingleThreadScanner.java
+++ b/src/main/java/com/ian/davidson/port/scanner/service/impl/SingleThreadScanner.java
@@ -1,6 +1,6 @@
 package com.ian.davidson.port.scanner.service.impl;
 
-import com.ian.davidson.port.scanner.config.ScannerConfig;
+import com.ian.davidson.port.scanner.async.AsyncConfig;
 import com.ian.davidson.port.scanner.model.entity.ConnectionStatus;
 import com.ian.davidson.port.scanner.model.entity.ScanResult;
 import com.ian.davidson.port.scanner.model.queue.ScanItinerary;
@@ -20,12 +20,12 @@ public class SingleThreadScanner implements Scanner {
 
     //https://stackoverflow.com/questions/10240694/java-socket-api-how-to-tell-if-a-connection-has-been-closed
 
+    private final AsyncConfig asyncConfig;
     private final ScanResultRepository scanResultRepository;
-    private final ScannerConfig scannerConfig;
 
-    public SingleThreadScanner(final ScanResultRepository scanResultRepository, final ScannerConfig scannerConfig) {
+    public SingleThreadScanner(final AsyncConfig asyncConfig, final ScanResultRepository scanResultRepository) {
+        this.asyncConfig = asyncConfig;
         this.scanResultRepository = scanResultRepository;
-        this.scannerConfig = scannerConfig;
     }
 
     @Override
@@ -39,7 +39,7 @@ public class SingleThreadScanner implements Scanner {
                     Socket socket = new Socket();
                     socket.connect(
                             new InetSocketAddress(address, port),
-                            scannerConfig.getTimeout()
+                            asyncConfig.getTimeout()
                     );
 
                     socket.close();
@@ -52,7 +52,7 @@ public class SingleThreadScanner implements Scanner {
                         .port(port)
                         .sessionId(scanItinerary.sessionId())
                         .status(success ? ConnectionStatus.OPEN : ConnectionStatus.CLOSED)
-                        .timeOut(scannerConfig.getTimeout())
+                        .timeOut(asyncConfig.getTimeout())
                         .build());
             }
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,22 @@ management:
       exposure:
         include: '*'
 
+
 spring:
+  #https://stackoverflow.com/questions/77405977/cannot-invoke-org-hibernate-engine-jdbc-spi-sqlexceptionhelper-convertjava-sql
+  #verify in docker run env, from here:
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    properties:
+      hibernate:
+        boot:
+          allow_jdbc_metadata_access: false
+    hibernate:
+      ddl-auto: update
+  sql:
+    init:
+      mode: never
+  #to here
   datasource:
     url: jdbc:postgresql://localhost:5432/postgres?current_schema=port_scanner
     username: postgres

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -57,7 +57,7 @@ spring:
 spring:
   config:
     activate:
-      on-profile: docker
+      on-profile: container
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     properties:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,22 +13,7 @@ management:
       exposure:
         include: '*'
 
-
 spring:
-  #https://stackoverflow.com/questions/77405977/cannot-invoke-org-hibernate-engine-jdbc-spi-sqlexceptionhelper-convertjava-sql
-  #verify in docker run env, from here:
-  jpa:
-    database-platform: org.hibernate.dialect.PostgreSQLDialect
-    properties:
-      hibernate:
-        boot:
-          allow_jdbc_metadata_access: false
-    hibernate:
-      ddl-auto: update
-  sql:
-    init:
-      mode: never
-  #to here
   datasource:
     url: jdbc:postgresql://localhost:5432/postgres?current_schema=port_scanner
     username: postgres
@@ -40,6 +25,7 @@ spring:
   rabbitmq:
     username: user
     password: password
+    port: 5672
 
 logging:
   level:
@@ -47,14 +33,43 @@ logging:
     com.ian.davidson.port.scanner.async: DEBUG
 
 scanner:
-  time-out: 200
-  thread-pool-core: 10
-  thread-pool-max: 40
-  thread-name-prefix: scanner-async-
-  queue-size: 500
+  async:
+    time-out: 200
+    thread-pool-core: 10
+    thread-pool-max: 40
+    thread-name-prefix: scanner-async-
+    queue-size: 500
+  rabbit:
+    queue-name: queue
+    topic-name-dispatch: dispatch
 
+---
 
+spring:
+  config:
+    activate:
+      on-profile: dev
+  rabbitmq:
+    host: localhost
 
-rabbit:
-  queue-name: queue
-  topic-name-dispatch: dispatch
+---
+
+spring:
+  config:
+    activate:
+      on-profile: docker
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    properties:
+      hibernate:
+        boot:
+          allow_jdbc_metadata_access: false
+    hibernate:
+      ddl-auto: update
+  sql:
+    init:
+      mode: never
+  datasource:
+    url: jdbc:postgresql://host.docker.internal:5432/postgres?current_schema=port_scanner
+  rabbitmq:
+    host: host.docker.internal

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -31,12 +31,12 @@ logging:
     root: INFO
 
 scanner:
-  time-out: 200
-  thread-pool-core: 10
-  thread-pool-max: 40
-  thread-name-prefix: scanner-async-
-  queue-size: 500
-
-rabbit:
-  queue-name: queue
-  topic-name-dispatch: dispatch
+  async:
+    time-out: 200
+    thread-pool-core: 10
+    thread-pool-max: 40
+    thread-name-prefix: scanner-async-
+    queue-size: 500
+  rabbit:
+    queue-name: queue
+    topic-name-dispatch: dispatch


### PR DESCRIPTION
- Update base image to match my machine's arch (mac arm64)
- add image tagging, don't forget to clear out old images on your machine
- add notion of "dev" and "container" spring profiles
- container profile leverages `host.docker.internal` rather than `localhost` for infrastructure
  - I am using docker desktop on mac, so this is the way to go about accessing ports on host for PSQl and RabbitMQ
- add active=dev to run configurations
- add active=container for jib when OCI image is built


~~Note to self: don't merge until DB validation is done using docker spring profile~~
Turns out when updating the `@Enum` column field on ScanResult invalidated some data in my db (it was storing the enum ordinal value rather than the actual enum string name). I just had to clear out invalid data and both dev and docker profiles work